### PR TITLE
U/danielsf/speed/up/get/gene/data/251104

### DIFF
--- a/src/abc_atlas_access/abc_atlas_cache/anndata_utils.py
+++ b/src/abc_atlas_access/abc_atlas_cache/anndata_utils.py
@@ -3,6 +3,7 @@ import time
 import pandas as pd
 import numpy as np
 import anndata
+import warnings
 from abc_atlas_access.abc_atlas_cache.abc_project_cache import AbcProjectCache
 
 
@@ -50,6 +51,14 @@ def get_gene_data(
     # Create a mask for the requested genes.
     gene_mask = np.isin(all_genes.gene_symbol, selected_genes)
     gene_filtered = all_genes[gene_mask]
+    if len(gene_filtered) > len(selected_genes):
+        msg = (
+            f"You asked for {len(selected_genes)} genes, but "
+            f"get_gene_data is selecting {len(gene_filtered)}; "
+            "probably some of the gene symbols you specified are "
+            "associated with more than one gene"
+        )
+        warnings.warn(msg)
 
     # wait to create output dataframe until we have read in the
     # first chunk and know the dtype we need


### PR DESCRIPTION
There is [a forum post](https://community.brain-map.org/t/get-gene-data-function-in-abc-atlas-access/4722/3) in which a user stumbled over the very large memory footprint of our `get_gene_data` utility. I think part of the problem is that we were populating a large DataFrame without telling pandas what dtype to expect. By specifying the dtype, I was able to get the memory footprint down by a factor of many*

*I ran a test case where I scanned WHB-10x for 500 genes. Before this PR, the process requested 50 GB on my workstation before I killed it. After this PR, the process ran to completion in 20 minutes, requiring 12 GB.